### PR TITLE
Fix margem alta no cálculo de lucro

### DIFF
--- a/src/utils/calcularLucro.js
+++ b/src/utils/calcularLucro.js
@@ -49,49 +49,14 @@ export const calcularLucroUnitario = ({
   const margemDecimal = margemLucroPercentual / 100;
   let precoIdeal = 0;
 
-  if (margemDecimal < 1) { // Evita divisão por zero ou negativo se margem >= 100%
-    precoIdeal = custoTotalUnitario / (1 - margemDecimal);
+  // Margens abaixo de 100% utilizam a fórmula tradicional.
+  // Para margens iguais ou superiores a 100%, aplica-se um simples markup
+  // sobre o custo total unitário para evitar divisões por zero ou valores
+  // negativos na fórmula anterior.
+  if (margemDecimal >= 1) {
+    precoIdeal = custoTotalUnitario * (1 + margemDecimal);
   } else {
-    // Se a margem desejada for 100% ou mais, o preço ideal tende ao infinito
-    // ou precisa de uma lógica de markup simples (Preço = Custo * (1 + Markup))
-    // Por simplicidade, aqui vamos considerar um markup se a margem for >= 100%
-    // Isso é uma interpretação, já que margem sobre o PREÇO não pode ser >= 100%
-    // Se for markup sobre o CUSTO: Preço = Custo * (1 + Margem)
-    // A fórmula PV = CTU / (1 - MargemDecimal) é para margem sobre o PREÇO DE VENDA.
-    // Se a intenção é markup sobre o CUSTO:
-    // precoIdeal = custoTotalUnitario * (1 + margemDecimal);
-    // Mantendo a fórmula original e tratando o caso extremo:
-    precoIdeal = custoTotalUnitario * (1 + margemDecimal); // Exemplo de markup sobre custo se margem >= 100%
-    // Ou pode-se lançar um erro ou retornar um valor indicativo de problema.
-    // Para este escopo, vamos assumir que margemLucroPercentual é sobre o preço de venda e < 100%.
-    // Se margemLucroPercentual for, por exemplo, 100%, a fórmula original daria divisão por zero.
-    // Se for 50%, PV = CTU / 0.5 (ou seja, o lucro é igual ao custo)
-    // Se a margem for 100% ou mais, a fórmula PV = CTU / (1-MD) não se aplica bem.
-    // Vamos recalcular precoIdeal para margens "normais" (<100%)
-    if (margemDecimal < 1 && (1 - margemDecimal) !== 0) {
-        precoIdeal = custoTotalUnitario / (1 - margemDecimal);
-    } else if (margemDecimal >=1 ) { // Para margens >= 100%, usar markup sobre o custo.
-        precoIdeal = custoTotalUnitario * (1 + margemDecimal);
-    } else { // Caso 1 - margemDecimal seja 0 (margem de 100%)
-        precoIdeal = custoTotalUnitario * 2; // Exemplo: Dobrar o custo se a margem for 100% do custo.
-                                           // Mas a fórmula original implicaria preço infinito.
-                                           // Vamos assumir que a margem é sobre o custo se for 100%
-                                           // Se a margem desejada é 100% do preço de venda, é impossível.
-                                           // Clarificando: margem de lucro é (Lucro/PreçoVenda).
-                                           // Lucro = PreçoVenda - CustoTotalUnitario
-                                           // Margem = (PreçoVenda - CustoTotalUnitario) / PreçoVenda
-                                           // Margem * PreçoVenda = PreçoVenda - CustoTotalUnitario
-                                           // CustoTotalUnitario = PreçoVenda - Margem * PreçoVenda
-                                           // CustoTotalUnitario = PreçoVenda * (1 - Margem)
-                                           // PreçoVenda = CustoTotalUnitario / (1 - Margem)
-                                           // Esta fórmula é válida para Margem < 1 (ou 100%)
-        if ((1-margemDecimal) <= 0) { // Se margem for 100% ou mais, não é possível pela fórmula tradicional.
-                                  // Adotaremos markup sobre o custo como fallback prático.
-            precoIdeal = custoTotalUnitario * (1 + margemDecimal);
-        } else {
-            precoIdeal = custoTotalUnitario / (1-margemDecimal);
-        }
-    }
+    precoIdeal = custoTotalUnitario / (1 - margemDecimal);
   }
 
 


### PR DESCRIPTION
## Summary
- fix lucro calculation when margemLucroPercentual exceeds 100%

## Testing
- `node -e "const { calcularLucroUnitario } = await import('./src/utils/calcularLucro.js'); console.log(calcularLucroUnitario({custoProduto: 10, custoFixoUnitario: 2, custoVariavelUnitario: 1, freteUnitario: 1, margemLucroPercentual: 50}));"`
- `node -e "const { calcularLucroUnitario } = await import('./src/utils/calcularLucro.js'); console.log(calcularLucroUnitario({custoProduto: 10, custoFixoUnitario: 2, custoVariavelUnitario: 1, freteUnitario: 1, margemLucroPercentual: 150}));"`

------
https://chatgpt.com/codex/tasks/task_e_683f3d44e62c8330b8ecf359370d6f6c